### PR TITLE
Made toast full width by default

### DIFF
--- a/packages/toast/toast.styl
+++ b/packages/toast/toast.styl
@@ -89,6 +89,7 @@
     white-space nowrap
     overflow hidden
     flex 1
-    max-width 70%
     margin 0
     padding 0
+    &.action
+      max-width 70%

--- a/packages/toast/toast.vue
+++ b/packages/toast/toast.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 .zi-toast-container
   .zi-toast(:class="type && type")
-    span.message {{ text }}
+    span.message(:class="{ action: action }") {{ text }}
     zi-button(
       v-if="action"
       auto ghost


### PR DESCRIPTION
if no action is passed - text should take up 100% of the width

## Change information

Currently, the text is cut off at 70% of the toast width even when no action is passed. This will fix the text width and use 100% of the width if no action is passed.

<img width="437" alt="Screen Shot 2020-06-10 at 12 02 02 AM" src="https://user-images.githubusercontent.com/585833/84237480-495bb600-aaae-11ea-9064-7fd813364edf.png">
