### PR TITLE
Changed toggle background from fixed color to CSS variable

### DIFF
--- a/packages/toggle/toggle.styl
+++ b/packages/toggle/toggle.styl
@@ -11,8 +11,8 @@
   cursor pointer
 
   &.checked
-    background-color #067df7
-    border 1px solid #067df7
+    background-color var(--geist-success)
+    border 1px solid var(--geist-success)
 
     &.disabled
       background-color var(--accents-4)


### PR DESCRIPTION
…ccess

## PR Checklist

- [x] Fix linting errors
- [x] Label has been added


## Change information

Changed the background- and border color of toggles from a fixed hex value (`#067df7`) to a CSS variable. I chose `--geist-success`, because it's the same one being used in `<zi-link>`
